### PR TITLE
Fix transparent background

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -32,7 +32,7 @@ function! s:highlight_helper(syntax_group, foreground_color, background_color)
   if a:background_color != ""
     exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=" . a:background_color . " gui=NONE cterm=NONE term=NONE"
   else
-    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=NONE gui=NONE cterm=NONE term=NONE"
+    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=" . s:nova_normal_black . " gui=NONE cterm=NONE term=NONE"
   endif
 endfunction
 
@@ -56,11 +56,11 @@ call s:highlight_helper("Normal", s:nova_normal_white, "")
 " ==================================================================
 
 " DECORATION
-call s:highlight_helper("SignColumn", "NONE", s:nova_normal_black)
+call s:highlight_helper("SignColumn", "NONE", "")
 call s:highlight_helper("LineNr", s:nova_decoration_medium, "")
 call s:highlight_helper("CursorLine", "NONE", s:nova_decoration_medium)
 call s:highlight_helper("CursorColumn", s:nova_decoration_medium, "")
-call s:highlight_helper("EndOfBuffer", s:nova_decoration_medium, s:nova_normal_black)
+call s:highlight_helper("EndOfBuffer", s:nova_decoration_medium, "")
 call s:highlight_helper("VertSplit", s:nova_decoration_medium, s:nova_decoration_medium)
 call s:highlight_helper("StatusLineNC", s:nova_normal_black, s:nova_decoration_medium)
 call s:highlight_helper("Pmenu", s:nova_normal_white, s:nova_decoration_light)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-vim",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {},
   "dependencies": {
     "nova-colors": "1.0.8"


### PR DESCRIPTION
Some interpretations of Vim default to a "transparent" background if not explicitly set. The background is now always explicitly set to fix this issue for Neovim + potentially others.

### Before

![image](https://cloud.githubusercontent.com/assets/5497885/18376030/8482245e-7618-11e6-9f52-a06fe233dbd4.png)
@statianzo and @mhartington were both having this problem with their Neovim setup.

### After
The background should be the a solid `novaColors.normal.black` (mid grey) like this:
<img width="1440" alt="screen shot 2016-09-08 at 11 06 28 pm" src="https://cloud.githubusercontent.com/assets/5497885/18376081/f25c4702-7618-11e6-8602-059a3f248e2c.png">

@statianzo and @mhartington, would you mind installing latest and letting me know if this did/didn't fix this issue for you? Thank you.
https://guides.github.com/features/mastering-markdown/