### PR TITLE
only set termguicolors if gui version of vim is used so that vim on t…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,9 @@ endfunction
 " CORE
 set background=dark
 highlight clear
-set termguicolors
+if has("gui_running")
+  set termguicolors
+endif
 set fillchars=""
 syntax on
 syntax reset


### PR DESCRIPTION
…erminal doesn't throw an error