### PR TITLE
Update git diff colors

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -57,8 +57,6 @@ call s:highlight_helper("ErrorMsg", "#DF8C8C", "")
 call s:highlight_helper("WarningMsg", "#DF8C8C", "")
 call s:highlight_helper("SpellBad", "#DF8C8C", "")
 call s:highlight_helper("SpellCap", "#DF8C8C", "")
-call s:highlight_helper("DiffChange", "#DF8C8C", "")
-call s:highlight_helper("DiffDelete", "#DF8C8C", "")
 call s:highlight_helper("Todo", "#DF8C8C", "")
 
 " USER CURRENT STATE
@@ -77,8 +75,13 @@ call s:highlight_helper("ModeMsg", "#7FC1CA", "")
 call s:highlight_helper("StatusLine", "#7FC1CA", "#556873")
 call s:highlight_helper("PmenuSel", "#556873", "#7FC1CA")
 call s:highlight_helper("PmenuThumb", "#7FC1CA", "#7FC1CA")
-call s:highlight_helper("DiffAdd", "#3C4C55", "#7FC1CA")
 call s:highlight_helper("CtrlPMatch", "#3C4C55", "#7FC1CA")
+
+" GIT
+call s:highlight_helper("DiffAdd", "#3C4C55", "#A8CE93")
+call s:highlight_helper("DiffChange", "#3C4C55", "#F2C38F")
+call s:highlight_helper("DiffDelete", "#DF8C8C", "")
+call s:highlight_helper("DiffText", "#3C4C55", "#F2C38F", "BOLD")
 
 " OTHER
 call s:highlight_helper("SignColumn", "NONE", "")
@@ -90,7 +93,6 @@ call s:highlight_helper("VertSplit", "#556873", "#556873")
 call s:highlight_helper("StatusLineNC", "#3C4C55", "#556873")
 call s:highlight_helper("Pmenu", "#C5D4DD", "#556873")
 call s:highlight_helper("PmenuSbar", "#899BA6", "#899BA6")
-call s:highlight_helper("DiffText", "#1E272C", "")
 call s:highlight_helper("ColorColumn", "#556873", "")
 
 

--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -5,12 +5,13 @@
 " HIGHLIGHT HELPER
 " ==================================================================
 
-function! s:highlight_helper(syntax_group, foreground_color, background_color)
-  if a:background_color != ""
-    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=" . a:background_color . " gui=NONE cterm=NONE term=NONE"
-  else
-    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=#3C4C55 gui=NONE cterm=NONE term=NONE"
-  endif
+function! s:highlight_helper(...)
+  let l:syntax_group = a:1
+  let l:foreground_color = a:2
+  let l:background_color = empty(a:3) ? "#3C4C55" : a:3
+  let l:gui = a:0 == 3 ? "None" : a:4
+
+  exec "highlight " . l:syntax_group . " guifg=" . l:foreground_color . " guibg=" . l:background_color . " gui=" . l:gui . " cterm=NONE term=NONE"
 endfunction
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-vim",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "scripts": {
     "start": "scripts/start",
     "push": "scripts/push",

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,6 @@ call s:highlight_helper("ErrorMsg", "${uiGroups.userActionNeeded}", "")
 call s:highlight_helper("WarningMsg", "${uiGroups.userActionNeeded}", "")
 call s:highlight_helper("SpellBad", "${uiGroups.userActionNeeded}", "")
 call s:highlight_helper("SpellCap", "${uiGroups.userActionNeeded}", "")
-call s:highlight_helper("DiffChange", "${uiGroups.userActionNeeded}", "")
-call s:highlight_helper("DiffDelete", "${uiGroups.userActionNeeded}", "")
 call s:highlight_helper("Todo", "${uiGroups.userActionNeeded}", "")
 
 " USER CURRENT STATE
@@ -81,8 +79,13 @@ call s:highlight_helper("ModeMsg", "${uiGroups.userCurrentState}", "")
 call s:highlight_helper("StatusLine", "${uiGroups.userCurrentState}", "${uiGroups.gray2}")
 call s:highlight_helper("PmenuSel", "${uiGroups.gray2}", "${uiGroups.userCurrentState}")
 call s:highlight_helper("PmenuThumb", "${uiGroups.userCurrentState}", "${uiGroups.userCurrentState}")
-call s:highlight_helper("DiffAdd", "${uiGroups.background}", "${uiGroups.userCurrentState}")
 call s:highlight_helper("CtrlPMatch", "${uiGroups.background}", "${uiGroups.userCurrentState}")
+
+" GIT
+call s:highlight_helper("DiffAdd", "${uiGroups.background}", "${versionControlGroups.added}")
+call s:highlight_helper("DiffChange", "${uiGroups.background}", "${versionControlGroups.modified}")
+call s:highlight_helper("DiffDelete", "${versionControlGroups.removed}", "")
+call s:highlight_helper("DiffText", "${uiGroups.background}", "${versionControlGroups.modified}", "BOLD")
 
 " OTHER
 call s:highlight_helper("SignColumn", "NONE", "")
@@ -94,7 +97,6 @@ call s:highlight_helper("VertSplit", "${uiGroups.gray2}", "${uiGroups.gray2}")
 call s:highlight_helper("StatusLineNC", "${uiGroups.background}", "${uiGroups.gray2}")
 call s:highlight_helper("Pmenu", "${uiGroups.foreground}", "${uiGroups.gray2}")
 call s:highlight_helper("PmenuSbar", "${uiGroups.gray4}", "${uiGroups.gray4}")
-call s:highlight_helper("DiffText", "${uiGroups.gray0}", "")
 call s:highlight_helper("ColorColumn", "${uiGroups.gray2}", "")
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,13 @@ const sourceString =`
 " HIGHLIGHT HELPER
 " ==================================================================
 
-function! s:highlight_helper(syntax_group, foreground_color, background_color)
-  if a:background_color != ""
-    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=" . a:background_color . " gui=NONE cterm=NONE term=NONE"
-  else
-    exec "highlight " . a:syntax_group . " guifg=" . a:foreground_color . " guibg=${uiGroups.background} gui=NONE cterm=NONE term=NONE"
-  endif
+function! s:highlight_helper(...)
+  let l:syntax_group = a:1
+  let l:foreground_color = a:2
+  let l:background_color = empty(a:3) ? "${uiGroups.background}" : a:3
+  let l:gui = a:0 == 3 ? "None" : a:4
+
+  exec "highlight " . l:syntax_group . " guifg=" . l:foreground_color . " guibg=" . l:background_color . " gui=" . l:gui . " cterm=NONE term=NONE"
 endfunction
 
 


### PR DESCRIPTION
- Updates the highlight helper to allow setting the `gui` property as well (for `bold` modifier)
- Update the diff view with to look like:

<img width="844" alt="screen shot 2016-10-12 at 11 29 47 pm" src="https://cloud.githubusercontent.com/assets/1645881/19338820/4870fc70-90d4-11e6-8cde-0c59a59eab7c.png">

Closes #38 