### PR TITLE
Supporting older version of Vim without termguicolors

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -23,6 +23,9 @@ endfunction
 set background=dark
 highlight clear
 set fillchars=""
+if (has("termguicolors"))
+  set termguicolors
+endif
 syntax on
 syntax reset
 let g:colors_name = "nova"

--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -22,7 +22,6 @@ endfunction
 " CORE
 set background=dark
 highlight clear
-set termguicolors
 set fillchars=""
 syntax on
 syntax reset

--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -22,10 +22,10 @@ endfunction
 " CORE
 set background=dark
 highlight clear
-set fillchars=""
 if (has("termguicolors"))
   set termguicolors
 endif
+set fillchars=""
 syntax on
 syntax reset
 let g:colors_name = "nova"


### PR DESCRIPTION
Older versions of Vim (`7.4` and below) don't have support for `termguicolors`. I've added a simple check that will enable it in new versions of Vim but now it will also gracefully degrade in older Vim versions without throwing this error:

```zsh
Unknown option: termguicolors
```