### PR TITLE
Update the color of the FZF statusline

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -251,3 +251,8 @@ call s:highlight_helper("EasyMotionTarget", "#DF8C8C", "", "BOLD")
 call s:highlight_helper("EasyMotionTarget2First", "#F2C38F", "")
 call s:highlight_helper("EasyMotionTarget2Second", "#DADA93", "")
 call s:highlight_helper("EasyMotionShade", "#899BA6", "")
+
+" FZF.vim
+call s:highlight_helper("fzf1", "#3C4C55", "#556873")
+call s:highlight_helper("fzf2", "#3C4C55", "#556873")
+call s:highlight_helper("fzf3", "#3C4C55", "#556873")

--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,11 @@ call s:highlight_helper("EasyMotionTarget", "${ansiGroups.normal.red}", "", "BOL
 call s:highlight_helper("EasyMotionTarget2First", "${ansiGroups.bright.red}", "")
 call s:highlight_helper("EasyMotionTarget2Second", "${ansiGroups.normal.yellow}", "")
 call s:highlight_helper("EasyMotionShade", "${syntaxGroups.trivial}", "")
+
+" FZF.vim
+call s:highlight_helper("fzf1", "${uiGroups.background}", "${uiGroups.gray2}")
+call s:highlight_helper("fzf2", "${uiGroups.background}", "${uiGroups.gray2}")
+call s:highlight_helper("fzf3", "${uiGroups.background}", "${uiGroups.gray2}")
 `
 
 process.stdout.write(sourceString)


### PR DESCRIPTION
Changes the default color of the FZF status line to be brown/red to instead match the color scheme.

**Before**

![screen shot 2017-02-27 at 10 52 34 am](https://cloud.githubusercontent.com/assets/1645881/23374902/13f748a0-fcdb-11e6-87f9-c7cf7319a534.png)

**After**

![screen shot 2017-02-27 at 10 52 18 am](https://cloud.githubusercontent.com/assets/1645881/23374905/179dd1a4-fcdb-11e6-90d3-37cda0bc2325.png)
