### PR TITLE
basic typescript support

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -158,6 +158,7 @@ call s:highlight_helper("jsonKeyword", "#83AFE5", "")
 call s:highlight_helper("xmlAttrib", "#83AFE5", "")
 call s:highlight_helper("netrwExe", "#83AFE5", "")
 call s:highlight_helper("shFunction", "#83AFE5", "")
+call s:highlight_helper("typescriptType", "#83AFE5", "")
 
 " STATEMENT
 call s:highlight_helper("Statement", "#DADA93", "")
@@ -180,6 +181,9 @@ call s:highlight_helper("jsFunction", "#A8CE93", "")
 call s:highlight_helper("jsStorageClass", "#A8CE93", "")
 call s:highlight_helper("jsNan", "#A8CE93", "")
 call s:highlight_helper("shFunctionKey", "#A8CE93", "")
+call s:highlight_helper("typescriptFuncKeyword", "#A8CE93", "")
+call s:highlight_helper("typescriptLabel", "#A8CE93", "")
+call s:highlight_helper("typescriptIdentifier", "#A8CE93", "")
 
 " GLOBAL
 call s:highlight_helper("PreProc", "#9A93E1", "")
@@ -188,6 +192,7 @@ call s:highlight_helper("jsThis", "#9A93E1", "")
 call s:highlight_helper("cssTagName", "#9A93E1", "")
 call s:highlight_helper("jsGlobalNodeObjects", "#9A93E1", "")
 call s:highlight_helper("cssFontDescriptor", "#9A93E1", "")
+call s:highlight_helper("typescriptReserved", "#9A93E1", "")
 
 " EMPHASIS
 call s:highlight_helper("Underlined", "#D18EC2", "")
@@ -225,6 +230,8 @@ call s:highlight_helper("markdownCodeDelimiter", "#F2C38F", "")
 call s:highlight_helper("netrwClassify", "#F2C38F", "")
 call s:highlight_helper("netrwVersion", "#F2C38F", "")
 call s:highlight_helper("CtrlPStats", "#F2C38F", "")
+call s:highlight_helper("typescriptBraces", "#F2C38F", "")
+call s:highlight_helper("typescriptParens", "#F2C38F", "")
 
 " TRIVIAL
 call s:highlight_helper("Comment", "#899BA6", "")
@@ -235,6 +242,7 @@ call s:highlight_helper("jsNoise", "#899BA6", "")
 call s:highlight_helper("cssClassNameDot", "#899BA6", "")
 call s:highlight_helper("jsonQuote", "#899BA6", "")
 call s:highlight_helper("shQuote", "#899BA6", "")
+call s:highlight_helper("typescriptEndColons", "#899BA6", "")
 
 
 " ==================================================================

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,7 @@ call s:highlight_helper("jsonKeyword", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("xmlAttrib", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("netrwExe", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("shFunction", "${syntaxGroups.identifier}", "")
+call s:highlight_helper("typescriptType", "${syntaxGroups.identifier}", "")
 
 " STATEMENT
 call s:highlight_helper("Statement", "${syntaxGroups.statement}", "")
@@ -184,6 +185,9 @@ call s:highlight_helper("jsFunction", "${syntaxGroups.type}", "")
 call s:highlight_helper("jsStorageClass", "${syntaxGroups.type}", "")
 call s:highlight_helper("jsNan", "${syntaxGroups.type}", "")
 call s:highlight_helper("shFunctionKey", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptFuncKeyword", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptLabel", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptIdentifier", "${syntaxGroups.type}", "")
 
 " GLOBAL
 call s:highlight_helper("PreProc", "${syntaxGroups.global}", "")
@@ -192,6 +196,7 @@ call s:highlight_helper("jsThis", "${syntaxGroups.global}", "")
 call s:highlight_helper("cssTagName", "${syntaxGroups.global}", "")
 call s:highlight_helper("jsGlobalNodeObjects", "${syntaxGroups.global}", "")
 call s:highlight_helper("cssFontDescriptor", "${syntaxGroups.global}", "")
+call s:highlight_helper("typescriptReserved", "${syntaxGroups.global}", "")
 
 " EMPHASIS
 call s:highlight_helper("Underlined", "${syntaxGroups.emphasis}", "")
@@ -229,6 +234,8 @@ call s:highlight_helper("markdownCodeDelimiter", "${syntaxGroups.special}", "")
 call s:highlight_helper("netrwClassify", "${syntaxGroups.special}", "")
 call s:highlight_helper("netrwVersion", "${syntaxGroups.special}", "")
 call s:highlight_helper("CtrlPStats", "${syntaxGroups.special}", "")
+call s:highlight_helper("typescriptBraces", "${syntaxGroups.special}", "")
+call s:highlight_helper("typescriptParens", "${syntaxGroups.special}", "")
 
 " TRIVIAL
 call s:highlight_helper("Comment", "${syntaxGroups.trivial}", "")
@@ -239,6 +246,7 @@ call s:highlight_helper("jsNoise", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("cssClassNameDot", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("jsonQuote", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("shQuote", "${syntaxGroups.trivial}", "")
+call s:highlight_helper("typescriptEndColons", "${syntaxGroups.trivial}", "")
 
 
 " ==================================================================


### PR DESCRIPTION
## Before
<img width="1546" alt="before" src="https://cloud.githubusercontent.com/assets/109635/25074971/288792be-22c6-11e7-977f-4728c89ffdd1.png">

## After
<img width="1546" alt="after" src="https://cloud.githubusercontent.com/assets/109635/25074970/2886fc32-22c6-11e7-906d-83477508e818.png">

This adds some really basic support for typescript using the most mainstream [typescript syntax](https://github.com/leafgarland/typescript-vim). Unfortunately, I couldn't get the level of granularity and detail I wanted to like we can with JavaScript. The TypeScript plugin marks a lof things as identifiers that are keywords, e.g. `const`. 

Would be nice to work with @leafgarland on extending the TypeScript syntax to add some of those things and we can be a complementary color scheme that leverages all those details like we currently do with vim-javascript.

