### PR TITLE
basic typescript support

### DIFF
--- a/colors/nova.vim
+++ b/colors/nova.vim
@@ -158,6 +158,8 @@ call s:highlight_helper("jsonKeyword", "#83AFE5", "")
 call s:highlight_helper("xmlAttrib", "#83AFE5", "")
 call s:highlight_helper("netrwExe", "#83AFE5", "")
 call s:highlight_helper("shFunction", "#83AFE5", "")
+call s:highlight_helper("typescriptVariableDeclaration", "#83AFE5", "")
+call s:highlight_helper("typescriptCall", "#83AFE5", "")
 
 " STATEMENT
 call s:highlight_helper("Statement", "#DADA93", "")
@@ -173,6 +175,10 @@ call s:highlight_helper("xmlEndTag", "#DADA93", "")
 call s:highlight_helper("xmlTagName", "#DADA93", "")
 call s:highlight_helper("xmlEqual", "#DADA93", "")
 call s:highlight_helper("shCmdSubRegion", "#DADA93", "")
+call s:highlight_helper("typescriptOperator", "#DADA93", "")
+call s:highlight_helper("typescriptOpSymbols", "#DADA93", "")
+call s:highlight_helper("typescriptProp", "#DADA93", "")
+
 
 " TYPE
 call s:highlight_helper("Type", "#A8CE93", "")
@@ -180,6 +186,10 @@ call s:highlight_helper("jsFunction", "#A8CE93", "")
 call s:highlight_helper("jsStorageClass", "#A8CE93", "")
 call s:highlight_helper("jsNan", "#A8CE93", "")
 call s:highlight_helper("shFunctionKey", "#A8CE93", "")
+call s:highlight_helper("typescriptEnumKeyword", "#A8CE93", "")
+call s:highlight_helper("typescriptVariable", "#A8CE93", "")
+call s:highlight_helper("typescriptFuncKeyword", "#A8CE93", "")
+call s:highlight_helper("typescriptDefault", "#A8CE93", "")
 
 " GLOBAL
 call s:highlight_helper("PreProc", "#9A93E1", "")
@@ -188,6 +198,9 @@ call s:highlight_helper("jsThis", "#9A93E1", "")
 call s:highlight_helper("cssTagName", "#9A93E1", "")
 call s:highlight_helper("jsGlobalNodeObjects", "#9A93E1", "")
 call s:highlight_helper("cssFontDescriptor", "#9A93E1", "")
+call s:highlight_helper("typescriptGlobal", "#9A93E1", "")
+call s:highlight_helper("typescriptExport", "#9A93E1", "")
+call s:highlight_helper("typescriptImport", "#9A93E1", "")
 
 " EMPHASIS
 call s:highlight_helper("Underlined", "#D18EC2", "")
@@ -225,6 +238,9 @@ call s:highlight_helper("markdownCodeDelimiter", "#F2C38F", "")
 call s:highlight_helper("netrwClassify", "#F2C38F", "")
 call s:highlight_helper("netrwVersion", "#F2C38F", "")
 call s:highlight_helper("CtrlPStats", "#F2C38F", "")
+call s:highlight_helper("typescriptParens", "#F2C38F", "")
+call s:highlight_helper("typescriptBraces", "#F2C38F", "")
+call s:highlight_helper("typescriptArrowFunc", "#F2C38F", "")
 
 " TRIVIAL
 call s:highlight_helper("Comment", "#899BA6", "")
@@ -235,7 +251,8 @@ call s:highlight_helper("jsNoise", "#899BA6", "")
 call s:highlight_helper("cssClassNameDot", "#899BA6", "")
 call s:highlight_helper("jsonQuote", "#899BA6", "")
 call s:highlight_helper("shQuote", "#899BA6", "")
-
+call s:highlight_helper("typescriptEndColons", "#899BA6", "")
+call s:highlight_helper("typescriptTemplateSB", "#899BA6", "")
 
 " ==================================================================
 " COMMON PLUGINS

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,8 @@ call s:highlight_helper("jsonKeyword", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("xmlAttrib", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("netrwExe", "${syntaxGroups.identifier}", "")
 call s:highlight_helper("shFunction", "${syntaxGroups.identifier}", "")
+call s:highlight_helper("typescriptVariableDeclaration", "${syntaxGroups.identifier}", "")
+call s:highlight_helper("typescriptCall", "${syntaxGroups.identifier}", "")
 
 " STATEMENT
 call s:highlight_helper("Statement", "${syntaxGroups.statement}", "")
@@ -177,6 +179,10 @@ call s:highlight_helper("xmlEndTag", "${syntaxGroups.statement}", "")
 call s:highlight_helper("xmlTagName", "${syntaxGroups.statement}", "")
 call s:highlight_helper("xmlEqual", "${syntaxGroups.statement}", "")
 call s:highlight_helper("shCmdSubRegion", "${syntaxGroups.statement}", "")
+call s:highlight_helper("typescriptOperator", "${syntaxGroups.statement}", "")
+call s:highlight_helper("typescriptOpSymbols", "${syntaxGroups.statement}", "")
+call s:highlight_helper("typescriptProp", "${syntaxGroups.statement}", "")
+
 
 " TYPE
 call s:highlight_helper("Type", "${syntaxGroups.type}", "")
@@ -184,6 +190,10 @@ call s:highlight_helper("jsFunction", "${syntaxGroups.type}", "")
 call s:highlight_helper("jsStorageClass", "${syntaxGroups.type}", "")
 call s:highlight_helper("jsNan", "${syntaxGroups.type}", "")
 call s:highlight_helper("shFunctionKey", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptEnumKeyword", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptVariable", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptFuncKeyword", "${syntaxGroups.type}", "")
+call s:highlight_helper("typescriptDefault", "${syntaxGroups.type}", "")
 
 " GLOBAL
 call s:highlight_helper("PreProc", "${syntaxGroups.global}", "")
@@ -192,6 +202,9 @@ call s:highlight_helper("jsThis", "${syntaxGroups.global}", "")
 call s:highlight_helper("cssTagName", "${syntaxGroups.global}", "")
 call s:highlight_helper("jsGlobalNodeObjects", "${syntaxGroups.global}", "")
 call s:highlight_helper("cssFontDescriptor", "${syntaxGroups.global}", "")
+call s:highlight_helper("typescriptGlobal", "${syntaxGroups.global}", "")
+call s:highlight_helper("typescriptExport", "${syntaxGroups.global}", "")
+call s:highlight_helper("typescriptImport", "${syntaxGroups.global}", "")
 
 " EMPHASIS
 call s:highlight_helper("Underlined", "${syntaxGroups.emphasis}", "")
@@ -229,6 +242,9 @@ call s:highlight_helper("markdownCodeDelimiter", "${syntaxGroups.special}", "")
 call s:highlight_helper("netrwClassify", "${syntaxGroups.special}", "")
 call s:highlight_helper("netrwVersion", "${syntaxGroups.special}", "")
 call s:highlight_helper("CtrlPStats", "${syntaxGroups.special}", "")
+call s:highlight_helper("typescriptParens", "${syntaxGroups.special}", "")
+call s:highlight_helper("typescriptBraces", "${syntaxGroups.special}", "")
+call s:highlight_helper("typescriptArrowFunc", "${syntaxGroups.special}", "")
 
 " TRIVIAL
 call s:highlight_helper("Comment", "${syntaxGroups.trivial}", "")
@@ -239,7 +255,8 @@ call s:highlight_helper("jsNoise", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("cssClassNameDot", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("jsonQuote", "${syntaxGroups.trivial}", "")
 call s:highlight_helper("shQuote", "${syntaxGroups.trivial}", "")
-
+call s:highlight_helper("typescriptEndColons", "${syntaxGroups.trivial}", "")
+call s:highlight_helper("typescriptTemplateSB", "${syntaxGroups.trivial}", "")
 
 " ==================================================================
 " COMMON PLUGINS


### PR DESCRIPTION
Adds typescript support, specifically targeting https://github.com/HerringtonDarkholme/yats.vim

<img width="1546" alt="ts" src="https://cloud.githubusercontent.com/assets/109635/25075214/688c1942-22cc-11e7-875a-e4e89c6176c0.png">

vim-javascript on the left and typescript on the right. 